### PR TITLE
log hapi response aborted

### DIFF
--- a/eventlogger/hapi_server.js
+++ b/eventlogger/hapi_server.js
@@ -31,7 +31,8 @@ module.exports.watch = function  (logger, server, options) {
       });
     }
 
-    if (tags.request && tags.closed) {
+    if (tags.request && tags.closed ||
+        tags.response && tags.aborted) {
       const abortLogEntry = createLogEntry(request, 'request_aborted');
       return logger.info(abortLogEntry, 'request aborted');
     }


### PR DESCRIPTION
If the request is aborted while the client is reading the response, hapi emits this:

```
{ response: true, error: true, aborted: true }
```

Please update this library in APIv2