### PR TITLE
Serialize auth0-client header from req

### DIFF
--- a/serializers/index.js
+++ b/serializers/index.js
@@ -31,6 +31,7 @@ var common_serializers = {
         'x-from-loc':          headers['x-from-loc'],
         'user-agent':          headers['user-agent'],
         'referer':             headers['referer'],
+        'auth0-client':        headers['auth0-client']
       },
       ip:       req.ip,
       route:    req.route && req.route.path

--- a/serializers/index.js
+++ b/serializers/index.js
@@ -7,6 +7,27 @@ var forbidden_headers = [
   'set-cookie'
 ];
 
+function parseClient (header) {
+  try {
+      const decode = Buffer.from(header, 'base64').toString();
+      let client = JSON.parse(decode);
+      if ('name' in client && 'version' in client) {
+          let obj = { 
+              'name': client.name, 
+              'version': client.version 
+          }
+          delete client.name;
+          delete client.version;
+          if (Object.keys(client)) {
+              obj['extra'] = Buffer.from(JSON.stringify(client)).toString('base64');
+          }
+          return obj;
+      }
+  } catch (e) {
+      return '';
+  }
+}
+
 var common_serializers = {
   req: function (req) {
     var headers = req.headers || {};
@@ -31,7 +52,7 @@ var common_serializers = {
         'x-from-loc':          headers['x-from-loc'],
         'user-agent':          headers['user-agent'],
         'referer':             headers['referer'],
-        'auth0-client':        headers['auth0-client']
+        'auth0-client':        parseClient(headers['auth0-client'])
       },
       ip:       req.ip,
       route:    req.route && req.route.path

--- a/serializers/index.js
+++ b/serializers/index.js
@@ -12,16 +12,16 @@ function parseClient (header) {
       const decode = Buffer.from(header, 'base64').toString();
       let client = JSON.parse(decode);
       if ('name' in client && 'version' in client) {
-          let obj = { 
+          let newHeader = { 
               'name': client.name, 
               'version': client.version 
-          }
+          };
           delete client.name;
           delete client.version;
           if (Object.keys(client)) {
-              obj['extra'] = Buffer.from(JSON.stringify(client)).toString('base64');
+            newHeader['extra'] = Buffer.from(JSON.stringify(client)).toString('base64');
           }
-          return obj;
+          return newHeader;
       }
   } catch (e) {
       return '';

--- a/test/common_serializers.tests.js
+++ b/test/common_serializers.tests.js
@@ -20,6 +20,23 @@ describe('serializers', function () {
 
   });
 
+  it('should serialize auth0-client header', function () {
+    var serialized = serializers.req({
+      headers: {
+        host: 'host.host.com',
+        'auth0-client': 'eyJuYW1lIjoiQXV0aDAuc3dpZnQiLCJ2ZXJzaW9uIjoiMS4xMC4xIiwic3dpZnQtdmVyc2lvbiI6IjMuMCJ9'
+      },
+      method: 'post',
+      path: '/foo/bar'
+    });
+
+    assert.equal(serialized.method, 'post');
+    assert.equal(serialized.host, 'host.host.com');
+    assert.equal(serialized.path, '/foo/bar');
+    assert.equal(serialized.headers['auth0-client'], 'eyJuYW1lIjoiQXV0aDAuc3dpZnQiLCJ2ZXJzaW9uIjoiMS4xMC4xIiwic3dpZnQtdmVyc2lvbiI6IjMuMCJ9');
+
+  });
+
   it('can be extended', function () {
     var my_serializers = _.extend({}, serializers, {
       req: function (req) {

--- a/test/common_serializers.tests.js
+++ b/test/common_serializers.tests.js
@@ -20,7 +20,7 @@ describe('serializers', function () {
 
   });
 
-  it('should serialize auth0-client header', function () {
+  it('should serialize auth0-client header and parse value', function () {
     var serialized = serializers.req({
       headers: {
         host: 'host.host.com',
@@ -33,8 +33,25 @@ describe('serializers', function () {
     assert.equal(serialized.method, 'post');
     assert.equal(serialized.host, 'host.host.com');
     assert.equal(serialized.path, '/foo/bar');
-    assert.equal(serialized.headers['auth0-client'], 'eyJuYW1lIjoiQXV0aDAuc3dpZnQiLCJ2ZXJzaW9uIjoiMS4xMC4xIiwic3dpZnQtdmVyc2lvbiI6IjMuMCJ9');
+    assert.equal(serialized.headers['auth0-client']['name'], 'Auth0.swift');
+    assert.equal(serialized.headers['auth0-client']['version'], '1.10.1');
+    assert.equal(serialized.headers['auth0-client']['extra'], 'eyJzd2lmdC12ZXJzaW9uIjoiMy4wIn0=');
+  });
 
+  it('should serialize auth0-client header with no value when invalid', function () {
+    var serialized = serializers.req({
+      headers: {
+        host: 'host.host.com',
+        'auth0-client': 'sdfasfasdfasdf324234234234='
+      },
+      method: 'post',
+      path: '/foo/bar'
+    });
+
+    assert.equal(serialized.method, 'post');
+    assert.equal(serialized.host, 'host.host.com');
+    assert.equal(serialized.path, '/foo/bar');
+    assert.equal(serialized.headers['auth0-client'], '');
   });
 
   it('can be extended', function () {


### PR DESCRIPTION
**What is the goal of this PR?**
To add the `auth0-client` header into the logstash for viewing in Kibana. This is a base64 encoded string that gives insight into the Auth0 SDK used.
It is useful for debugging and currently we are defining an RFC to standardise this information across all SDKs.

_Example:_
eyJuYW1lIjoiQXV0aDAuc3dpZnQiLCJ2ZXJzaW9uIjoiMS4xMC4xIiwic3dpZnQtdmVyc2lvbiI6IjMuMCJ9

_Decoded:_ 
{"name":"Auth0.swift","version":"1.10.1","swift-version":"3.0"}

**Extracting Information**
The only constants are `name` and `version` so these keys will be extracted and added to the header.  Any additional information will be re-encoded as base64 and put under an `extra` key.

_Space considerations?_
This adds a small additional storage requirement, don't know if this is an issue at scale? Will check with `core-infra`

**How did I test?**
Added a test to ensure the header was seralized