### PR TITLE
Fix serializer error when response is null

### DIFF
--- a/serializers/index.js
+++ b/serializers/index.js
@@ -37,6 +37,7 @@ var common_serializers = {
     };
   },
   res: function (res) {
+    if (!res) return {};
     var headers = res.headers || {};
     var result = {
       statusCode: res.statusCode,

--- a/test/common_serializers.tests.js
+++ b/test/common_serializers.tests.js
@@ -20,6 +20,13 @@ describe('serializers', function () {
 
   });
 
+  it('should return an empty object if response is not defined', function () {
+    var serialized = serializers.res();
+
+    assert.deepEqual(serialized, {});
+
+  });
+
   it('can be extended', function () {
     var my_serializers = _.extend({}, serializers, {
       req: function (req) {


### PR DESCRIPTION
Using this with hapi17, I found that in cases where the request was aborted (the client disconnected while the request was in flight), the response was actually null, so we'd get this nasty error:

```
bunyan: ERROR: Exception thrown from the "res" Bunyan serializer. This should never happen. This is a bug in that serializer function.
TypeError: Cannot read property 'headers' of null
    at Object.res (/app/node_modules/auth0-instrumentation/node_modules/auth0-common-logging/serializers/index.js:40:23)
    at /app/node_modules/bunyan/lib/bunyan.js:873:50
    at Array.forEach (<anonymous>)
    at Logger._applySerializers (/app/node_modules/bunyan/lib/bunyan.js:865:35)
    at mkRecord (/app/node_modules/bunyan/lib/bunyan.js:978:17)
    at Logger.info (/app/node_modules/bunyan/lib/bunyan.js:1044:19)
    at Object.formatLog [as info] (/app/node_modules/auth0-instrumentation/lib/utils.js:57:26)
    at Object.onRequestClosedOrAborted [as listener] (/app/node_modules/auth0-common-logging/eventlogger/hapi_server_v17.js:47:14)
(etc...)
```
