### PR TITLE
Fix serializer by checking res exists

### DIFF
--- a/serializers/index.js
+++ b/serializers/index.js
@@ -37,6 +37,8 @@ var common_serializers = {
     };
   },
   res: function (res) {
+    if (!res || !res.statusCode) { return; }
+
     var headers = res.headers || {};
     var result = {
       statusCode: res.statusCode,


### PR DESCRIPTION
When a connection is closed and we don't override the serializer, we have this issue in logs

```
bunyan: ERROR: Exception thrown from the "res" Bunyan serializer. This should never happen. This is a bug in that serializer function.
TypeError: Cannot read property 'headers' of null
    at Object.res (/app/node_modules/auth0-common-logging/serializers/index.js:40:23)
    at /app/node_modules/bunyan/lib/bunyan.js:873:50
    at Array.forEach (<anonymous>)
    at Logger._applySerializers (/app/node_modules/bunyan/lib/bunyan.js:865:35)
    at mkRecord (/app/node_modules/bunyan/lib/bunyan.js:978:17)
    at Logger.info (/app/node_modules/bunyan/lib/bunyan.js:1044:19)
    at Object.formatLog [as info] (/app/node_modules/auth0-instrumentation/lib/utils.js:57:26)
    at Object.onRequestClosedOrAborted [as listener] (/app/node_modules/auth0-common-logging/eventlogger/hapi_server_v17.js:47:14)
    at module.exports.internals.Podium.internals.Podium.emit (/app/node_modules/podium/lib/index.js:228:107)
    at Request._log (/app/node_modules/hapi/lib/request.js:494:27)
    at IncomingMessage.internals.event (/app/node_modules/hapi/lib/request.js:548:13)
    at emitNone (events.js:106:13)
    at IncomingMessage.emit (events.js:208:7)
    at abortIncoming (_http_server.js:424:9)
    at socketOnEnd (_http_server.js:440:5)
    at emitNone (events.js:111:20)
    at Socket.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1064:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickDomainCallback (internal/process/next_tick.js:218:9)
[2019-05-03T20:06:31.223Z]  INFO: authorization-api/150 on dc3059375a83: request aborted (log_type=request_aborted, took=21350, req.host=localhost:8080, req.path=/tenants/login0/roles, req.route=/tenants/{tenantName}/roles, req.tenant=login0)
    get /tenants/login0/roles?page=0&per_page=1&include_totals=false HTTP/1.1
    accept: */*
    host: localhost:8080
    user-agent: curl/7.38.0
    --
    process: {
      "app": "authorization-api",
      "version": "1.0.0",
      "node": "v8.11.0"
    }
    --
    res: (Error in Bunyan log "res" serializer broke field. See stderr for details.)
```

APIv2 is doing this too: https://github.com/auth0/api2/blob/master/lib/logger/serializers.js#L64