### PR TITLE
Add `obfuscatePayload` and `stringifyPayload` options for Hapi loggers

### DIFF
--- a/eventlogger/hapi_server.js
+++ b/eventlogger/hapi_server.js
@@ -1,12 +1,17 @@
 var requests_start_time = {};
 var assign = require('lodash').assign;
+var obfuscator = require('../lib/obfuscator');
 
 module.exports.watch = function  (logger, server, options) {
   options = assign({}, {
-    ignorePaths: []
+    ignorePaths: [],
+    obfuscatePayload: false,
+    stringifyPayload: false
   }, options);
 
   var ignorePaths = options.ignorePaths;
+  var obfuscatePayload = options.obfuscatePayload;
+  var stringifyPayload = options.stringifyPayload;
 
   function createLogEntry(request, log_type) {
     const took = Date.now() - requests_start_time[request.id];
@@ -47,14 +52,19 @@ module.exports.watch = function  (logger, server, options) {
     const level = tags.debug ? 'debug': 'info';
     logger[level]({ req: request, data: data.data });
   }).on('request-error', function (request, error) {
+    let payload = request.pre && request.pre._originalPayload || request.payload;
+    if (obfuscatePayload) {
+      payload = obfuscator.obfuscateSafe(payload);
+    }
+    if (stringifyPayload) {
+      payload = JSON.stringify(payload);
+    }
     logger.error({
       log_type: 'request_error',
       req: request,
       res: request.response,
       err: error,
-      payload: request.pre &&
-               request.pre._originalPayload ||
-               request.payload
+      payload
     }, error.message);
   }).on('log', function (event, tags) {
     logger.info({

--- a/lib/obfuscator.js
+++ b/lib/obfuscator.js
@@ -1,0 +1,32 @@
+const traverse = require('traverse');
+
+const MAX_LEAF_COUNT = 250;
+
+const obfuscate = function(obj) {
+  let leafCount = 0;
+  return traverse(obj).map(function(x) {
+    if (this.isLeaf) {
+      leafCount++;
+      if (leafCount > MAX_LEAF_COUNT) {
+        throw new Error('object is too large to obfuscate');
+      }
+    }
+    if (this.isLeaf && x !== null) {
+      return typeof x;
+    }
+  });
+};
+
+const obfuscateSafe = function(obj) {
+  try {
+    return obfuscate(obj);
+  } catch (e) {
+    return e.message;
+  }
+};
+
+module.exports = {
+  obfuscate,
+  obfuscateSafe
+};
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-common-logging",
-  "version": "2.22.1",
+  "version": "2.23.0",
   "description": "Utilities to write logs in auth0 components.",
   "main": "index.js",
   "scripts": {
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.11",
-    "request": "^2.27.0"
+    "request": "^2.27.0",
+    "traverse": "^0.6.6"
   }
 }

--- a/test/hapi_server.tests.js
+++ b/test/hapi_server.tests.js
@@ -7,118 +7,270 @@ const eventLogger = new EventLogger(bunyan.createLogger({
   name: 'test'
 }));
 
-var hapi_plugin = {
-  register: function(server, options, next) {
-    eventLogger.watch(server, { ignorePaths: ['/ignored'] });
-    next();
-  }
-};
+const startServer = (eventLoggerOptions, cb) => {
+  var hapi_plugin = {
+    register: function (server, options, next) {
+      eventLogger.watch(server, eventLoggerOptions);
+      next();
+    }
+  };
 
-hapi_plugin.register.attributes = {
-  name: 'bunyan-logger',
-  version: '1.0.0'
+  hapi_plugin.register.attributes = {
+    name: 'bunyan-logger',
+    version: '1.0.0'
+  };
+
+  const server = new Hapi.Server();
+  server.connection({ host: 'localhost', port: 9876 });
+  server.route({
+    method: 'GET',
+    path: '/',
+    handler: function (request, reply) {
+      return reply('Hello world!');
+    }
+  });
+  server.route({
+    method: 'GET',
+    path: '/ignored',
+    handler: function (request, reply) {
+      return reply('ignored!');
+    }
+  });
+  server.route({
+    method: 'GET',
+    path: '/slow',
+    handler: function (request, reply) {
+      setTimeout(function () {
+        return reply('Hellooooooo sloooooow woooooorld!');
+      }, 1500);
+    }
+  });
+  server.route({
+    method: 'POST',
+    path: '/internal_error',
+    handler: function (request, reply) {
+      return reply(new Error('test error'));
+    }
+  });
+  server.start(cb);
+  server.register(hapi_plugin, function (err) {
+    if (err) {
+      console.log('Failed to load Hapi plugin');
+    }
+  });
+  return server;
 };
 
 describe('watch Hapi server < v17', function () {
+  var loggerSave = {};
+
   var server;
 
-  before(function(done) {
-    server = new Hapi.Server();
-    server.connection({ host:'localhost', port: 9876 });
-    server.route({
-      method: 'GET',
-      path: '/',
-      handler: function(request, reply) {
-        return reply('Hello world!');
-      }
-    });
-    server.route({
-      method: 'GET',
-      path: '/ignored',
-      handler: function(request, reply) {
-        return reply('ignored!');
-      }
-    });
-    server.route({
-      method: 'GET',
-      path: '/slow',
-      handler: function(request, reply) {
-        setTimeout(function() {
-          return reply('Hellooooooo sloooooow woooooorld!');
-        }, 1500);
-      }
-    });
-    server.start(done);
-    server.register(hapi_plugin, function(err) {
-      if (err) {
-        console.log('Failed to load Hapi plugin');
-      }
-    });
+  before(function() {
+    loggerSave.info = eventLogger.logger.info;
+    loggerSave.error = eventLogger.logger.error;
+  });
+  afterEach(function() {
+    eventLogger.logger.info = function() {};
+    eventLogger.logger.error = function() {};
+  });
+  after(function() {
+    // Restore saved logger functions to avoid test cross-contamination
+    eventLogger.logger.info = loggerSave.info;
+    eventLogger.logger.error = loggerSave.error;
   });
 
-  after(function (done) {
-    server.stop(done);
-  });
-
-  it('should log response time', function (done) {
-    eventLogger.logger.info = function(log_event) {
-      if (log_event.log_type === 'request') {
-        return;
-      }
-
-      assert.isNumber(log_event.took);
-      assert.isAbove(log_event.took, 0);
+  const whenARequestRaisesAnError = function(cb) {
+    const opts = {
+      url: server.info.uri + '/internal_error',
+      body: { a: 't' },
+      json: true
     };
+    request.post(opts, cb);
+  };
 
-    request.get(server.info.uri + '/', function (error, response, body) {
-      assert.equal(body, 'Hello world!');
-      done();
+  describe('with default options', function () {
+    before(function (done) {
+      const eventLoggerOptions = {};
+      server = startServer(eventLoggerOptions, done);
+    });
+
+    after(function (done) {
+      server.stop(done);
+    });
+
+    it('should log response time', function (done) {
+      eventLogger.logger.info = function (log_event) {
+        if (log_event.log_type === 'request') {
+          return;
+        }
+
+        assert.isNumber(log_event.took);
+        assert.isAbove(log_event.took, 0);
+      };
+
+      request.get(server.info.uri + '/', function (error, response, body) {
+        assert.equal(body, 'Hello world!');
+        done();
+      });
+    });
+
+    it('should log request on aborted request', function (done) {
+      eventLogger.logger.info = function (log_event, msg) {
+        if (log_event.log_type === 'request') {
+          return;
+        }
+        assert.isNumber(log_event.took);
+        assert.isAbove(log_event.took, 0);
+        assert.equal(log_event.log_type, 'request_aborted');
+        assert.isString(log_event.req.id);
+        assert.equal(msg, 'request aborted');
+        done();
+      };
+
+      const req = request.get(server.info.uri + '/slow', () => {});
+
+      setTimeout(() => {
+        req.abort();
+      }, 50);
+    });
+
+    it('should log response time in a slow endpoint', function (done) {
+      eventLogger.logger.info = function (log_event) {
+        if (log_event.log_type === 'request') {
+          return;
+        }
+
+        assert.isNumber(log_event.took);
+        assert.isAbove(log_event.took, 1500);
+      };
+      request.get(server.info.uri + '/slow', function (error, response, body) {
+        assert.equal(body, 'Hellooooooo sloooooow woooooorld!');
+        done();
+      });
+    });
+
+    it('should log server errors', function (done) {
+      let event = null;
+      let message = null;
+
+      eventLogger.logger.error = function (log_event, msg) {
+        event = log_event;
+        message = msg;
+      };
+
+      whenARequestRaisesAnError(function () {
+        assert.isNotNull(event);
+        assert.equal(message, 'test error');
+        assert.equal(event.log_type, 'request_error');
+        assert.deepEqual(event.payload, { a: 't' });
+        done();
+      });
     });
   });
 
-  it('should log request on aborted request', function (done) {
-    eventLogger.logger.info = function(log_event, msg) {
-      if (log_event.log_type === 'request') {
-        return;
-      }
-      assert.isNumber(log_event.took);
-      assert.isAbove(log_event.took, 0);
-      assert.equal(log_event.log_type, 'request_aborted');
-      assert.isString(log_event.req.id);
-      assert.equal(msg, 'request aborted');
-      done();
-    };
+  describe('with ignorePaths set', function () {
+    before(function (done) {
+      const eventLoggerOptions = { ignorePaths: ['/ignored'] };
+      server = startServer(eventLoggerOptions, done);
+    });
 
-    const req = request.get(server.info.uri + '/slow', () => {});
+    after(function (done) {
+      server.stop(done);
+    });
 
-    setTimeout(() => {
-      req.abort();
-    }, 50);
-  });
-
-  it('should log response time in a slow endpoint', function (done) {
-    eventLogger.logger.info = function(log_event) {
-      if (log_event.log_type === 'request') {
-        return;
-      }
-
-      assert.isNumber(log_event.took);
-      assert.isAbove(log_event.took, 1500);
-    };
-    request.get(server.info.uri + '/slow', function (error, response, body) {
-      assert.equal(body, 'Hellooooooo sloooooow woooooorld!');
-      done();
+    it('should not log ignored endpoints', function (done) {
+      eventLogger.logger.info = function () {
+        throw done(new Error('info should not have been called'));
+      };
+      request.get(server.info.uri + '/ignored', function (error, response, body) {
+        assert.equal(body, 'ignored!');
+        done();
+      });
     });
   });
 
-  it('should not log ignored endpoints', function (done) {
-    eventLogger.logger.info = function(log_event) {
-      throw done(new Error('info should not have been called'));
-    };
-    request.get(server.info.uri + '/ignored', function (error, response, body) {
-      assert.equal(body, 'ignored!');
-      done();
+  describe('with obfuscatePayload set', function () {
+    before(function (done) {
+      const eventLoggerOptions = { obfuscatePayload: true };
+      server = startServer(eventLoggerOptions, done);
+    });
+
+    after(function (done) {
+      server.stop(done);
+    });
+
+    it('should log obfuscated payload on error', function (done) {
+      let event = null;
+      let message = null;
+
+      eventLogger.logger.error = function (log_event, msg) {
+        event = log_event;
+        message = msg;
+      };
+
+      whenARequestRaisesAnError(function () {
+        assert.isNotNull(event);
+        assert.equal(event.log_type, 'request_error');
+        assert.deepEqual(event.payload, { a: 'string' });
+        done();
+      });
     });
   });
 
+  describe('with stringifyPayload set', function () {
+    before(function (done) {
+      var eventLoggerOptions = { stringifyPayload: true };
+      server = startServer(eventLoggerOptions, done);
+    });
+
+    after(function (done) {
+      server.stop(done);
+    });
+
+    it('should log stringified payload on error', function (done) {
+      let event = null;
+      let message = null;
+
+      eventLogger.logger.error = function (log_event, msg) {
+        event = log_event;
+        message = msg;
+      };
+
+      whenARequestRaisesAnError(function () {
+        assert.isNotNull(event);
+        assert.equal(event.log_type, 'request_error');
+        assert.equal(event.payload, '{"a":"t"}');
+        done();
+      });
+    });
+  });
+
+  describe('with obfuscatePayload and stringifyPayload set', function () {
+    before(function (done) {
+      var eventLoggerOptions = { stringifyPayload: true, obfuscatePayload: true };
+      server = startServer(eventLoggerOptions, done);
+    });
+
+    after(function (done) {
+      server.stop(done);
+    });
+
+    it('should log obfuscated+stringified payload on error', function (done) {
+      let event = null;
+      let message = null;
+
+      eventLogger.logger.error = function (log_event, msg) {
+        event = log_event;
+        message = msg;
+      };
+
+      whenARequestRaisesAnError(function () {
+        assert.isNotNull(event);
+        assert.equal(event.log_type, 'request_error');
+        assert.equal(event.payload, '{"a":"string"}');
+        done();
+      });
+    });
+  });
 });

--- a/test/hapi_server_v17.tests.node8.js
+++ b/test/hapi_server_v17.tests.node8.js
@@ -7,147 +7,285 @@ const eventLogger = new EventLogger(bunyan.createLogger({
   name: 'test'
 }));
 
-var hapi_plugin = {
-  register: function(server, options) {
-    return eventLogger.watch(server, { ignorePaths: ['/ignored'] });
-  },
-  name: 'bunyan-logger',
-  version: '1.0.0',
-};
+var null_logger = function () { return; };
 
-var null_logger = function() { return; };
+const startServer = async function(eventLoggerOptions) {
+  var hapi_plugin = {
+    register: function (server) {
+      return eventLogger.watch(server, eventLoggerOptions);
+    },
+    name: 'bunyan-logger',
+    version: '1.0.0',
+  };
+
+  const server = Hapi.server({ host: 'localhost', port: 9877 });
+  server.route({
+    method: 'GET',
+    path: '/',
+    handler: function() {
+      return 'Hello world!';
+    }
+  });
+  server.route({
+    method: 'GET',
+    path: '/ignored',
+    handler: function() {
+      return 'ignored!';
+    }
+  });
+  server.route({
+    method: 'GET',
+    path: '/slow',
+    handler: function() {
+      return new Promise((resolve) => {
+        setTimeout(resolve, 1500, 'Hellooooooo sloooooow woooooorld!');
+      });
+    }
+  });
+  server.route({
+    method: 'GET',
+    path: '/internal_error',
+    handler: async function() {
+      throw new Error('test error');
+    }
+  });
+  server.route({
+    method: 'POST',
+    path: '/internal_error',
+    handler: async function() {
+      throw new Error('test error');
+    }
+  });
+  await server.register(hapi_plugin);
+  await server.start();
+  return server;
+};
 
 describe('watch Hapi server v17', function () {
   var server;
   var loggerSave = {};
 
-  before(async function() {
+  before(function() {
     eventLogger.logger.info = null_logger;
     loggerSave.info = eventLogger.logger.info;
     loggerSave.error = eventLogger.logger.error;
-
-    server = Hapi.server({ host: 'localhost', port: 9877 });
-    server.route({
-      method: 'GET',
-      path: '/',
-      handler: function() {
-        return 'Hello world!';
-      }
-    });
-    server.route({
-      method: 'GET',
-      path: '/ignored',
-      handler: function() {
-        return 'ignored!';
-      }
-    });
-    server.route({
-      method: 'GET',
-      path: '/slow',
-      handler: function() {
-        return new Promise((resolve) => {
-          setTimeout(resolve, 1500, 'Hellooooooo sloooooow woooooorld!');
-        });
-      }
-    });
-    server.route({
-      method: 'GET',
-      path: '/internal_error',
-      handler: async function() {
-        throw new Error('test error');
-      }
-    });
-    await server.register(hapi_plugin);
-    return server.start();
   });
-
-  after(function() {
-    return server.stop();
-  })
 
   afterEach(function() {
     // Restored saved logger functions to avoid test cross-contamination
     eventLogger.logger.info = loggerSave.info;
     eventLogger.logger.error = loggerSave.error;
-  })
-  
+  });
 
-  it('should log response time', function (done) {
-    eventLogger.logger.info = function(log_event) {
-      if (log_event.log_type === 'request') {
-        return;
-      }
-
-      assert.isNumber(log_event.took);
-      assert.isAbove(log_event.took, 0);
+  const whenARequestRaisesAnError = function(cb) {
+    const opts = {
+      url: server.info.uri + '/internal_error',
+      body: { a: 't' },
+      json: true
     };
-    request.get(server.info.uri + '/', function (error, response, body) {
-      assert.equal(body, 'Hello world!');
-      done();
+    request.post(opts, cb);
+  };
+
+  describe('with default options', function () {
+    before(async function() {
+      const eventLoggerOptions = {};
+      server = await startServer(eventLoggerOptions);
+    });
+
+    after(function() {
+      return server.stop();
+    });
+
+    it('should log response time', function (done) {
+      eventLogger.logger.info = function(log_event) {
+        if (log_event.log_type === 'request') {
+          return;
+        }
+
+        assert.isNumber(log_event.took);
+        assert.isAbove(log_event.took, 0);
+      };
+      request.get(server.info.uri + '/', function (error, response, body) {
+        assert.equal(body, 'Hello world!');
+        done();
+      });
+    });
+
+    it('should log request on aborted request', function (done) {
+      eventLogger.logger.info = function(log_event, msg) {
+        if (log_event.log_type === 'request') {
+          return;
+        }
+
+        assert.isNumber(log_event.took);
+        assert.isAbove(log_event.took, 0);
+        assert.equal(log_event.log_type, 'request_aborted');
+        assert.isString(log_event.req.info.id);
+        assert.equal(msg, 'request aborted');
+        done();
+      };
+
+      const req = request.get(server.info.uri + '/slow', () => {});
+
+      setTimeout(() => {
+        req.abort();
+      }, 50);
+    });
+
+    it('should log response time in a slow endpoint', function (done) {
+      eventLogger.logger.info = function(log_event) {
+        if (log_event.log_type === 'request') {
+          return;
+        }
+
+        assert.isNumber(log_event.took);
+        assert.isAbove(log_event.took, 1500);
+      };
+      request.get(server.info.uri + '/slow', function (error, response, body) {
+        assert.equal(body, 'Hellooooooo sloooooow woooooorld!');
+        done(error);
+      });
+    });
+
+    it('should log error appropriately', function(done) {
+      let event = null;
+      let message = null;
+
+      eventLogger.logger.error = function(log_event, msg) {
+        event = log_event;
+        message = msg;
+      };
+
+      request.get(server.info.uri + '/internal_error', function () {
+        assert.isNotNull(event);
+        assert.equal(event.log_type, 'request_error');
+        assert.equal(event.payload, null);
+        assert.typeOf(event.err, 'Error');
+        assert.equal(message, 'test error');
+        done();
+      });
+    });
+
+    it('should log payload on error', function(done) {
+      let event = null;
+      let message = null;
+
+      eventLogger.logger.error = function(log_event, msg) {
+        event = log_event;
+        message = msg;
+      };
+
+      whenARequestRaisesAnError(function () {
+        assert.isNotNull(event);
+        assert.equal(event.log_type, 'request_error');
+        assert.deepEqual(event.payload, { a: 't' });
+        done();
+      });
     });
   });
 
-  it('should log request on aborted request', function (done) {
-    eventLogger.logger.info = function(log_event, msg) {
-      if (log_event.log_type === 'request') {
-        return;
-      }
+  describe('with ignorePaths set', function () {
+    before(async function() {
+      const eventLoggerOptions = { ignorePaths: ['/ignored'] };
+      server = await startServer(eventLoggerOptions);
+    });
 
-      assert.isNumber(log_event.took);
-      assert.isAbove(log_event.took, 0);
-      assert.equal(log_event.log_type, 'request_aborted');
-      assert.isString(log_event.req.info.id);
-      assert.equal(msg, 'request aborted');
-      done();
-    };
+    after(function() {
+      return server.stop();
+    });
 
-    const req = request.get(server.info.uri + '/slow', () => {});
-
-    setTimeout(() => {
-      req.abort();
-    }, 50);
-  });
-
-  it('should log response time in a slow endpoint', function (done) {
-    eventLogger.logger.info = function(log_event) {
-      if (log_event.log_type === 'request') {
-        return;
-      }
-
-      assert.isNumber(log_event.took);
-      assert.isAbove(log_event.took, 1500);
-    };
-    request.get(server.info.uri + '/slow', function (error, response, body) {
-      assert.equal(body, 'Hellooooooo sloooooow woooooorld!');
-      done(error);
+    it('should not log ignored endpoints', function (done) {
+      eventLogger.logger.info = function() {
+        done(new Error('info should not have been called'));
+      };
+      request.get(server.info.uri + '/ignored', function (error, response, body) {
+        assert.equal(body, 'ignored!');
+        done();
+      });
     });
   });
 
-  it('should log error appropriately', function(done) {
-    let event = null;
-    let message = null;
+  describe('with obfuscatePayload set', function () {
+    before(async function() {
+      const eventLoggerOptions = { obfuscatePayload: true };
+      server = await startServer(eventLoggerOptions);
+    });
 
-    eventLogger.logger.error = function(log_event, msg) {
-      event = log_event;
-      message = msg;
-    };
+    after(function() {
+      return server.stop();
+    });
 
-    request.get(server.info.uri + '/internal_error', function (error, response, body) {
-      assert.isNotNull(event);
-      assert.equal(event.log_type, 'request_error');
-      assert.typeOf(event.err, 'Error');
-      assert.equal(message, 'test error');
-      done();
-    })
+    it('should log obfuscated payload on error', function(done) {
+      let event = null;
+      let message = null;
+
+      eventLogger.logger.error = function(log_event, msg) {
+        event = log_event;
+        message = msg;
+      };
+
+      whenARequestRaisesAnError(function () {
+        assert.isNotNull(event);
+        assert.equal(event.log_type, 'request_error');
+        assert.deepEqual(event.payload, { a: 'string' });
+        done();
+      });
+    });
   });
 
-  it('should not log ignored endpoints', function (done) {
-    eventLogger.logger.info = function() {
-      done(new Error('info should not have been called'));
-    };
-    request.get(server.info.uri + '/ignored', function (error, response, body) {
-      assert.equal(body, 'ignored!');
-      done();
+  describe('with stringifyPayload set', function () {
+    before(async function() {
+      const eventLoggerOptions = { stringifyPayload: true };
+      server = await startServer(eventLoggerOptions);
+    });
+
+    after(function() {
+      return server.stop();
+    });
+
+    it('should log stringified payload on error', function(done) {
+      let event = null;
+      let message = null;
+
+      eventLogger.logger.error = function(log_event, msg) {
+        event = log_event;
+        message = msg;
+      };
+
+      whenARequestRaisesAnError(function () {
+        assert.isNotNull(event);
+        assert.equal(event.log_type, 'request_error');
+        assert.equal(event.payload, '{"a":"t"}');
+        done();
+      });
+    });
+  });
+
+  describe('with obfuscatePayload and stringifyPayload set', function () {
+    before(async function() {
+      const eventLoggerOptions = { obfuscatePayload: true, stringifyPayload: true };
+      server = await startServer(eventLoggerOptions);
+    });
+
+    after(function() {
+      return server.stop();
+    });
+
+    it('should log obfuscated+stringified payload on error', function(done) {
+      let event = null;
+      let message = null;
+
+      eventLogger.logger.error = function(log_event, msg) {
+        event = log_event;
+        message = msg;
+      };
+
+      whenARequestRaisesAnError(function () {
+        assert.isNotNull(event);
+        assert.equal(event.log_type, 'request_error');
+        assert.equal(event.payload, '{"a":"string"}');
+        done();
+      });
     });
   });
 

--- a/test/obfuscator.tests.js
+++ b/test/obfuscator.tests.js
@@ -1,0 +1,81 @@
+const expect = require('chai').expect;
+const _ = require('lodash');
+const obfuscator = require('../lib/obfuscator');
+
+describe('obfuscator', () => {
+  describe('obfuscate()', () => {
+    it('should obfuscate strings with "string"', () => {
+      const actual = obfuscator.obfuscate({ a: 'some_string' });
+      expect(actual).to.eql({ a: 'string' });
+    });
+
+    it('should obfuscate numbers with "number"', () => {
+      const actual = obfuscator.obfuscate({ a: 10 });
+      expect(actual).to.eql({ a: 'number' });
+    });
+
+    it('should obfuscate booleans with "boolean"', () => {
+      const actual = obfuscator.obfuscate({ a: false });
+      expect(actual).to.eql({ a: 'boolean' });
+    });
+
+    it('should keep null untouched', () => {
+      const actual = obfuscator.obfuscate({ a: null });
+      expect(actual).to.eql({ a: null });
+    });
+
+    it('should report undefined as a string', () => {
+      const actual = obfuscator.obfuscate({ a: undefined });
+      expect(actual).to.eql({ a: 'undefined' });
+    });
+
+    it('should walk down child object', () => {
+      const actual = obfuscator.obfuscate({ a: { b: 'some_string' } });
+      expect(actual).to.eql({ a: { b: 'string' } });
+    });
+
+    it('should walk down child array', () => {
+      const actual = obfuscator.obfuscate({ a: ['some_string'] });
+      expect(actual).to.eql({ a: ['string'] });
+    });
+
+    it('should not mutate input object', () => {
+      const input = { a: 'some_string' };
+      obfuscator.obfuscate(input);
+      expect(input).to.eql({ a: 'some_string' });
+    });
+
+    it('should support `null` payload', () => {
+      const actual = obfuscator.obfuscate(null);
+      expect(actual).to.eql(null);
+    });
+
+    it('should support string payload', () => {
+      const actual = obfuscator.obfuscate('some_string');
+      expect(actual).to.eql('string');
+    });
+
+    it('should throw on big objects', () => {
+      const input = { a: _.times(1000, () => 'some_string') };
+      expect(() => obfuscator.obfuscate(input)).to.throw('object is too large to obfuscate');
+    });
+  });
+
+  describe('obfuscateSafe()', () => {
+    it('should return a string when processing big objects', () => {
+      const input = { a: _.times(1000, () => 'some_string') };
+      const actual = obfuscator.obfuscateSafe(input);
+      expect(actual).to.eql('object is too large to obfuscate');
+    });
+
+    it('should return the error message when an unexpected error occurs', () => {
+      const input = {
+        get a() {
+          throw new Error('expected error');
+        }
+      };
+      const actual = obfuscator.obfuscateSafe(input);
+      expect(actual).to.eql('expected error');
+    });
+  });
+});


### PR DESCRIPTION
## Description

Add support for two new options: `obfuscatePayload` and `stringifyPayload`, meant to be used in combination with the Hapi.js event loggers. Applies to Hapi <17 and Hapi >17 plugins.

```
const EventLogger = require('auth0-common-logging').EventLogger;
const eventLogger = new EventLogger(logger);
eventLogger.watch(server, {
  obfuscatePayload: true, // default=false
  stringifyPayload: true  // default=false
});
```

These options control how we log the `payload` content of the request when a Hapi `request-error` event occurs. It's usually very helpful to log the payload for debugging purposes, but because it can contain sensitive information, it is sometimes preferable to hide the attribute values. `obfuscatePayload` will retain the "shape" of the payload but will replace values with a string that indicates the data type:

```
{
  "a": "some_string",
  "b": 12
  "c": null
}
```

becomes:
```
{
  "a": "string",
  "b": "number"
  "c": null
}
```

If the payload has more than 250 attributes in total, we discard the payload completely to 1) prevent logging an excessively large entry and 2) limit the processing time to obfuscate.

`stringifyPayload` also affects the logged payload object and is meant to convert the payload object to a plain string. This is preferable when using structured logging + ElasticSearch as it makes the cardinality of log entries predictable.

Bumps the version to v2.23.0

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
