### PR TITLE
fix(serializer): express get resp header

### DIFF
--- a/serializers/index.js
+++ b/serializers/index.js
@@ -38,7 +38,7 @@ var common_serializers = {
   },
   res: function (res) {
     if (!res) return {};
-    var headers = res.headers || {};
+    var headers = (typeof res.getHeaders === 'function') ? res.getHeaders() : headers || {};
     var result = {
       statusCode: res.statusCode,
       headers:    {

--- a/serializers/index.js
+++ b/serializers/index.js
@@ -38,7 +38,7 @@ var common_serializers = {
   },
   res: function (res) {
     if (!res) return {};
-    var headers = (typeof res.getHeaders === 'function') ? res.getHeaders() : headers || {};
+    var headers = (typeof res.getHeaders === 'function') ? res.getHeaders() : res.headers || {};
     var result = {
       statusCode: res.statusCode,
       headers:    {


### PR DESCRIPTION
Express extends the `ServerResponse` in node core. Since v7 [`res.getHeaders()`](https://nodejs.org/api/http.html#http_response_getheaders) will return the desired results.

This repo has been holding onto v6 compatibility (should sunset). If this seems like an acceptable direction will add tests.