### PR TITLE
Protect against deep payload objects + improve obfuscated token

### DIFF
--- a/lib/obfuscator.js
+++ b/lib/obfuscator.js
@@ -1,18 +1,21 @@
 const traverse = require('traverse');
 
-const MAX_LEAF_COUNT = 250;
+const MAX_WEIGHT = 250;
 
 const obfuscate = function(obj) {
-  let leafCount = 0;
-  return traverse(obj).map(function(x) {
-    if (this.isLeaf) {
-      leafCount++;
-      if (leafCount > MAX_LEAF_COUNT) {
-        throw new Error('object is too large to obfuscate');
-      }
+  let weight = 0;
+  return traverse(obj).map(function(value) {
+    weight += (this.isLeaf) ? 1 : 1.75;
+    if (weight > MAX_WEIGHT) {
+      throw new Error('object is too large to obfuscate');
     }
-    if (this.isLeaf && x !== null) {
-      return typeof x;
+
+    if (this.isLeaf && value !== null) {
+      if (value === undefined) {
+        return '<undefined>';
+      }
+      const type = typeof value;
+      return `<redacted_${type}>`;
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-common-logging",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "description": "Utilities to write logs in auth0 components.",
   "main": "index.js",
   "scripts": {

--- a/test/hapi_server.tests.js
+++ b/test/hapi_server.tests.js
@@ -212,7 +212,7 @@ describe('watch Hapi server < v17', function () {
       whenARequestRaisesAnError(function () {
         assert.isNotNull(event);
         assert.equal(event.log_type, 'request_error');
-        assert.deepEqual(event.payload, { a: 'string' });
+        assert.deepEqual(event.payload, { a: '<redacted_string>' });
         done();
       });
     });
@@ -268,7 +268,7 @@ describe('watch Hapi server < v17', function () {
       whenARequestRaisesAnError(function () {
         assert.isNotNull(event);
         assert.equal(event.log_type, 'request_error');
-        assert.equal(event.payload, '{"a":"string"}');
+        assert.equal(event.payload, '{"a":"<redacted_string>"}');
         done();
       });
     });

--- a/test/hapi_server_v17.tests.node8.js
+++ b/test/hapi_server_v17.tests.node8.js
@@ -227,7 +227,7 @@ describe('watch Hapi server v17', function () {
       whenARequestRaisesAnError(function () {
         assert.isNotNull(event);
         assert.equal(event.log_type, 'request_error');
-        assert.deepEqual(event.payload, { a: 'string' });
+        assert.deepEqual(event.payload, { a: '<redacted_string>' });
         done();
       });
     });
@@ -283,7 +283,7 @@ describe('watch Hapi server v17', function () {
       whenARequestRaisesAnError(function () {
         assert.isNotNull(event);
         assert.equal(event.log_type, 'request_error');
-        assert.equal(event.payload, '{"a":"string"}');
+        assert.equal(event.payload, '{"a":"<redacted_string>"}');
         done();
       });
     });

--- a/test/obfuscator.tests.js
+++ b/test/obfuscator.tests.js
@@ -6,17 +6,17 @@ describe('obfuscator', () => {
   describe('obfuscate()', () => {
     it('should obfuscate strings with "string"', () => {
       const actual = obfuscator.obfuscate({ a: 'some_string' });
-      expect(actual).to.eql({ a: 'string' });
+      expect(actual).to.eql({ a: '<redacted_string>' });
     });
 
     it('should obfuscate numbers with "number"', () => {
       const actual = obfuscator.obfuscate({ a: 10 });
-      expect(actual).to.eql({ a: 'number' });
+      expect(actual).to.eql({ a: '<redacted_number>' });
     });
 
     it('should obfuscate booleans with "boolean"', () => {
       const actual = obfuscator.obfuscate({ a: false });
-      expect(actual).to.eql({ a: 'boolean' });
+      expect(actual).to.eql({ a: '<redacted_boolean>' });
     });
 
     it('should keep null untouched', () => {
@@ -26,17 +26,17 @@ describe('obfuscator', () => {
 
     it('should report undefined as a string', () => {
       const actual = obfuscator.obfuscate({ a: undefined });
-      expect(actual).to.eql({ a: 'undefined' });
+      expect(actual).to.eql({ a: '<undefined>' });
     });
 
     it('should walk down child object', () => {
       const actual = obfuscator.obfuscate({ a: { b: 'some_string' } });
-      expect(actual).to.eql({ a: { b: 'string' } });
+      expect(actual).to.eql({ a: { b: '<redacted_string>' } });
     });
 
     it('should walk down child array', () => {
       const actual = obfuscator.obfuscate({ a: ['some_string'] });
-      expect(actual).to.eql({ a: ['string'] });
+      expect(actual).to.eql({ a: ['<redacted_string>'] });
     });
 
     it('should not mutate input object', () => {
@@ -52,11 +52,18 @@ describe('obfuscator', () => {
 
     it('should support string payload', () => {
       const actual = obfuscator.obfuscate('some_string');
-      expect(actual).to.eql('string');
+      expect(actual).to.eql('<redacted_string>');
     });
 
-    it('should throw on big objects', () => {
+    it('should throw on big objects (wide)', () => {
       const input = { a: _.times(1000, () => 'some_string') };
+      expect(() => obfuscator.obfuscate(input)).to.throw('object is too large to obfuscate');
+    });
+
+    it('should throw on big objects (deep)', () => {
+      const input = _.times(1000).reduce((acc) => {
+        return { x: acc };
+      }, {});
       expect(() => obfuscator.obfuscate(input)).to.throw('object is too large to obfuscate');
     });
   });


### PR DESCRIPTION
### Description

In previous PR (#22), we protected the obfuscator from big objects by counting the leaf attributes. But this does not protect against iterating on deeply nested properties. This PR adds a guard against this.

The tokens used for obfuscation have been improved as well.
- `"string"` -> `"<redacted_string>"`
- `"number"` -> `"<redacted_number>"`
- `"boolean` -> `"<redacted_boolean>"`
- `"undefined"` -> `"<undefined>"`

Bump version to 2.25.1

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
