### PR TITLE
Avoid breaking req serializer when there are no headers

### DIFF
--- a/serializers/index.js
+++ b/serializers/index.js
@@ -13,7 +13,7 @@ var common_serializers = {
     return {
       id:       req._tracking_id,
       method:   req.method,
-      host:     req.headers['host'],
+      host:     headers['host'],
       path:     req.path,
       headers:   {
         'content-type':        headers['content-type'],


### PR DESCRIPTION
As we can see we have the "headers" object which allows the serializer to break when there are no headers, host is the only one that wasn't being using it
