### PR TITLE
Support logging an item on response by decorating request object

### DIFF
--- a/eventlogger/log_item_collector.js
+++ b/eventlogger/log_item_collector.js
@@ -1,0 +1,39 @@
+const _ = require('lodash');
+
+const MAX_LOG_ITEMS = 20;
+
+module.exports = (logger) => {
+  let items = [];
+
+  function addValue(key, value) {
+    if (items.length > MAX_LOG_ITEMS) {
+      // This prevents memory leaks by not allowing an infinite amount
+      // of objects to be collected as part of log items
+      logger.error({
+        log_type: 'too_many_log_on_response',
+        items
+      },
+      'The maximum amount of data to log has been exceed. We will ' +
+      'log existing items as part of this error and cleanup items');
+
+      items = [];
+    }
+
+    items.push({ key, value });
+  }
+
+  function injectOn(carrier) {
+    if (typeof carrier !== 'object' || carrier === null) {
+      return;
+    }
+
+    for (let item of items) {
+      _.set(carrier, item.key, item.value);
+    }
+  }
+
+  return {
+    addValue,
+    injectOn
+  };
+};

--- a/test/hapi_server.tests.js
+++ b/test/hapi_server.tests.js
@@ -31,6 +31,15 @@ const startServer = (eventLoggerOptions, cb) => {
   });
   server.route({
     method: 'GET',
+    path: '/log_on_response',
+    handler: function(req, reply) {
+      req.logOnResponse('obj.value', 'test');
+
+      return reply('Hello world!');
+    }
+  });
+  server.route({
+    method: 'GET',
     path: '/ignored',
     handler: function (request, reply) {
       return reply('ignored!');
@@ -146,6 +155,20 @@ describe('watch Hapi server < v17', function () {
       };
       request.get(server.info.uri + '/slow', function (error, response, body) {
         assert.equal(body, 'Hellooooooo sloooooow woooooorld!');
+        done();
+      });
+    });
+
+    it('should log items on response time', function (done) {
+      eventLogger.logger.info = function(log_event) {
+        if (log_event.log_type === 'request') {
+          return;
+        }
+
+        assert.equal(log_event.obj.value, 'test');
+      };
+      request.get(server.info.uri + '/log_on_response', function (error, response, body) {
+        assert.equal(body, 'Hello world!');
         done();
       });
     });

--- a/test/hapi_server_v17.tests.node8.js
+++ b/test/hapi_server_v17.tests.node8.js
@@ -28,6 +28,15 @@ const startServer = async function(eventLoggerOptions) {
   });
   server.route({
     method: 'GET',
+    path: '/log_on_response',
+    handler: function(req) {
+      req.logOnResponse('obj.value', 'test');
+
+      return 'Hello world!';
+    }
+  });
+  server.route({
+    method: 'GET',
     path: '/ignored',
     handler: function() {
       return 'ignored!';
@@ -106,6 +115,20 @@ describe('watch Hapi server v17', function () {
         assert.isAbove(log_event.took, 0);
       };
       request.get(server.info.uri + '/', function (error, response, body) {
+        assert.equal(body, 'Hello world!');
+        done();
+      });
+    });
+
+    it('should log items on response time', function (done) {
+      eventLogger.logger.info = function(log_event) {
+        if (log_event.log_type === 'request') {
+          return;
+        }
+
+        assert.equal(log_event.obj.value, 'test');
+      };
+      request.get(server.info.uri + '/log_on_response', function (error, response, body) {
         assert.equal(body, 'Hello world!');
         done();
       });


### PR DESCRIPTION
This is a similar functionality to the one we have in other places and allows as to add properties to the response log, this is useful to log the state of rate limits and things like those without having to add an extra log.